### PR TITLE
Fix provider comparison in user creation

### DIFF
--- a/src/main/java/com/demo/springcustomizedstarterexample/services/webapp/user/UserServiceImpl.java
+++ b/src/main/java/com/demo/springcustomizedstarterexample/services/webapp/user/UserServiceImpl.java
@@ -81,7 +81,8 @@ public class UserServiceImpl implements UserService {
         if (ObjectUtils.isEmpty(requestUserDTO.getRoles())) {
             requestUserDTO.setRoles(Set.of(AppSecurityUtils.ROLE_DEFAULT));
         }
-        boolean isFromCustomBasicAuth = requestUserDTO.getRegisteredProviderName().equals(requestUserDTO.getRegisteredProviderName());
+        boolean isFromCustomBasicAuth = SecurityEnums.AuthProviderId.app_custom_authentication
+                .equals(requestUserDTO.getRegisteredProviderName());
         if (isFromCustomBasicAuth && requestUserDTO.getPassword() != null) {
             requestUserDTO.setPassword(passwordEncoder.encode(requestUserDTO.getPassword()));
         }


### PR DESCRIPTION
## Summary
- ensure correct provider comparison when creating users

## Testing
- `sh mvnw -q test` *(fails: Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_6873cf661d30832a87951ad866ca795f